### PR TITLE
fix: pip install encoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author="Christoph Rieke",
     author_email="christoph.k.rieke@gmail.com",
     description="",
-    long_description=parent_dir.joinpath("README.md").read_text(),
+    long_description=parent_dir.joinpath("README.md").read_text(encoding='utf-8'),
     long_description_content_type="text/markdown",
     url="https://github.com/chrieke/prettymapp",
     license="MIT",


### PR DESCRIPTION
Hey, first off nice app :) but I got an encoding error installing it via pip. 

```
(venv) C:\Users\td\Desktop\prettymapp>pip install git+https://github.com/chrieke/prettymapp.git
Collecting git+https://github.com/chrieke/prettymapp.git
  Cloning https://github.com/chrieke/prettymapp.git to c:\users\td\appdata\local\temp\pip-req-build-nc4pk_ft
  Running command git clone --filter=blob:none --quiet https://github.com/chrieke/prettymapp.git 'C:\Users\td\AppData\Local\Temp\pip-req-build-nc4pk_ft'
  Resolved https://github.com/chrieke/prettymapp.git to commit 34b75b5adce0a10a064344fbc2da449dfdcf29a3
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\td\AppData\Local\Temp\pip-req-build-nc4pk_ft\setup.py", line 12, in <module>
          long_description=parent_dir.joinpath("README.md").read_text(),
        File "C:\Program Files\Python39\lib\pathlib.py", line 1267, in read_text
          return f.read()
        File "C:\Program Files\Python39\lib\encodings\cp1252.py", line 23, in decode
          return codecs.charmap_decode(input,self.errors,decoding_table)[0]
      UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 19: character maps to <undefined>
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```