### PR TITLE
pin osmnx subdependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 osmnx==1.2.2
+numpy==1.22.3 #osmnx subdependecies are unpinned
+matplotlib==3.5.1


### PR DESCRIPTION
pin osmnx subdependencies to avoid numpy version leading to partial rendering, see https://github.com/chrieke/prettymapp/issues/9