### PR TITLE
experiment - deactivate osmnx cache due to st traffic

### DIFF
--- a/prettymapp/osm.py
+++ b/prettymapp/osm.py
@@ -6,7 +6,7 @@ from shapely.geometry import Polygon
 from prettymapp.geo import explode_multigeometries
 from prettymapp.settings import LC_SETTINGS
 
-settings.use_cache = True
+settings.use_cache = False
 settings.log_console = False
 
 


### PR DESCRIPTION
Since the public st app is overwhelmed with traffic due to the hackernews post deactivating osmnx caching as it seems to be problematic with too many users. 

Will likely revert later / add better public config options / only activate for the public st app.