### PR TITLE
Add credit toggle

### DIFF
--- a/prettymapp/plotting.py
+++ b/prettymapp/plotting.py
@@ -55,6 +55,7 @@ class Plot:
     text_x: int = 0
     text_y: int = 0
     text_rotation: int = 0
+    credit: bool = True
     # Map background settings
     bg_shape: str = "rectangle"
     bg_buffer: int = 2
@@ -93,7 +94,8 @@ class Plot:
             self.set_map_contour()
         if self.name_on:
             self.set_name()
-        self.set_credits(add_package_credit=True)
+        if self.credit is True:
+            self.set_credits(add_package_credit=True)
 
         return self.fig
 


### PR DESCRIPTION
### Overview

I'm using this library with my plotter to create some map art!  While all OpenStreetMap data should be properly attributed, I'd rather do this on the back side of my art pieces as opposed to the front.  This PR adds the ability to disable the credit text in the corner using [the same toggle as the original prettymaps library uses](https://github.com/marceloprates/prettymaps/issues/121).  Also like the original library (and to keep backwards compatibility), it defaults to `True` to encourage users to credit things properly. 