### PR TITLE
Fix accidental usage of default LANDCOVER_CLASSES

### DIFF
--- a/prettymapp/osm.py
+++ b/prettymapp/osm.py
@@ -82,7 +82,7 @@ def get_osm_geometries(
     """
     tags = get_osm_tags(landcover_classes=landcover_classes)
     df = features_from_polygon(polygon=aoi, tags=tags)
-    df = cleanup_osm_df(df, aoi)
+    df = cleanup_osm_df(df, aoi, landcover_classes=landcover_classes)
     return df
 
 
@@ -99,5 +99,5 @@ def get_osm_geometries_from_xml(
     """
     tags = get_osm_tags(landcover_classes=landcover_classes)
     df = features_from_xml(filepath, polygon=aoi, tags=tags)
-    df = cleanup_osm_df(df, aoi)
+    df = cleanup_osm_df(df, aoi, landcover_classes=landcover_classes)
     return df


### PR DESCRIPTION
None of the calls to cleanup_osm_df would previously previde the landcover_classes argument, resulting in this function always using the default `settings.LANDCOVER_CLASSES`.

This happened to mostly work fine
when taking a shallow copy and mutating said copy, but if one were to do something that replaces it or a dict inside it then those changes would be (mostly) ignored.

Specifically the following cases previously did not work correctly:

Overwriting a root key with a new object
```
custom_lc_classes["water"] = {}
```
Taking a deep copy of the entire landcover classes
```
custom_lc_classes = copy.deepcopy(LANDCOVER_CLASSES)
```
Adding a new custom class
```
custom_lc_classes["farmland"] = {"landuse": ["farmland"]}
```
With this change the above examples all work as expected.

This should fix one issue seen by @makew0rld: https://github.com/chrieke/prettymapp/issues/60#issuecomment-2540320722 