### PR TITLE
Fix show_credits variable

### DIFF
--- a/prettymapp/plotting.py
+++ b/prettymapp/plotting.py
@@ -102,7 +102,7 @@ class Plot:
             self.set_map_contour()
         if self.name_on:
             self.set_name()
-        if self.show_credits:
+        if self.credits:
             self.set_credits()
 
         return self.fig


### PR DESCRIPTION
Fixes the following error
```
Traceback (most recent call last):
  File "/mnt/map.py", line 51, in <module>
    ).plot_all()
      ~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/prettymapp/plotting.py", line 105, in plot_all
    if self.show_credits:
       ^^^^^^^^^^^^^^^^^
AttributeError: 'Plot' object has no attribute 'show_credits'. Did you mean: 'set_credits'?
```