### PR TITLE
Fix wrong message on text input for custom_title

### DIFF
--- a/streamlit-prettymapp/app.py
+++ b/streamlit-prettymapp/app.py
@@ -47,7 +47,7 @@ if index_selected != st.session_state["previous_example_index"]:
     st.session_state["previous_example_index"] = index_selected
 
 st.write("")
-form = st.form(key="form_settings")
+form = st.form(key="form_settings", enter_to_submit=False)
 col1, col2, col3 = form.columns([3, 1, 1])
 
 address = col1.text_input(


### PR DESCRIPTION
Issue: #77 
In the form at custom_title the text_input field says: Press enter to submit form. But it is not happening, so i turn off the function: enter_to_submit in the form.