### PR TITLE
General robustness improvements

### DIFF
--- a/prettymapp/geo.py
+++ b/prettymapp/geo.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Optional
-
 from osmnx.geocoder import geocode
 from geopandas import GeoDataFrame
 import pandas as pd
@@ -20,8 +18,8 @@ def validate_coordinates(lat: float, lon: float) -> None:
 
 
 def get_aoi(
-    address: Optional[str] = None,
-    coordinates: Optional[Tuple[float, float]] = None,
+    address: str | None = None,
+    coordinates: tuple[float, float] | None = None,
     radius: int = 1000,
     rectangular: bool = False,
 ) -> Polygon:
@@ -43,10 +41,19 @@ def get_aoi(
                 "Both address and latlon coordinates were provided, please "
                 "select only one!"
             )
+        if not address.strip():
+            raise GeoCodingError("No address provided, please enter a location.")
         try:
             lat, lon = geocode(address)
         except ValueError as e:
             raise GeoCodingError(f"Could not geocode address '{address}'") from e
+        except Exception as e:  # pylint: disable=broad-except
+            # osmnx/requests surface network, timeout and HTTP errors as a range of
+            # exception types; treat them all as a transient geocoding failure.
+            raise GeoCodingError(
+                f"Could not reach the geocoding service while looking up "
+                f"'{address}'. Please try again."
+            ) from e
     else:
         if coordinates is None:
             raise ValueError("Either 'address' or 'coordinates' must be provided.")

--- a/prettymapp/osm.py
+++ b/prettymapp/osm.py
@@ -1,4 +1,3 @@
-from typing import Union
 from pathlib import Path
 
 from osmnx.features import features_from_polygon, features_from_xml
@@ -13,10 +12,14 @@ settings.use_cache = True
 settings.log_console = False
 
 
+class OsmDataError(Exception):
+    """Raised when no usable OSM features are available for the query."""
+
+
 def get_osm_tags(landcover_classes: dict = LANDCOVER_CLASSES):
     """
     Get relevant OSM tags for use with prettymapp
-    
+
     Args:
         landcover_classes: Landcover selection settings, defaults to prettymapp.settings.LANDCOVER_CLASSES
         E.g.
@@ -37,17 +40,26 @@ def get_osm_tags(landcover_classes: dict = LANDCOVER_CLASSES):
 
 
 def cleanup_osm_df(
-    df: GeoDataFrame, aoi: Union[Polygon, None] = None, landcover_classes: dict = LANDCOVER_CLASSES
+    df: GeoDataFrame,
+    aoi: Polygon | None = None,
+    landcover_classes: dict = LANDCOVER_CLASSES,
 ) -> GeoDataFrame:
     """
     Cleanup of queried osm geometries to relevant level for use with prettymapp
-    
+
     Args:
         df: GeoDataFrame with queried OSM geometries
         aoi: Optional geographic boundary to filter elements
         landcover_classes: Landcover selection settings, defaults to prettymapp.settings.LANDCOVER_CLASSES
+
+    Raises:
+        OsmDataError: If no usable OSM features remain after cleanup.
     """
-    df = df.droplevel(level=0)
+    if df.empty:
+        raise OsmDataError("No OSM features found for this area.")
+    # osmnx returns a (element_type, osmid) MultiIndex; drop the element_type level.
+    if df.index.nlevels > 1:
+        df = df.droplevel(level=0)
     df = df[~df.geometry.geom_type.isin(["Point", "MultiPoint"])]
     if aoi is not None:
         df = clip(df, aoi)
@@ -73,6 +85,12 @@ def cleanup_osm_df(
         df.columns.difference(["geometry", "landcover_class", "highway"]), axis=1
     )
 
+    if df.empty:
+        raise OsmDataError(
+            "No OSM features matching the prettymapp landcover classes were "
+            "found for this area."
+        )
+
     return df
 
 
@@ -93,7 +111,9 @@ def get_osm_geometries(
 
 
 def get_osm_geometries_from_xml(
-    filepath: Union[str, Path], aoi: Union[Polygon, None] = None, landcover_classes: dict = LANDCOVER_CLASSES
+    filepath: str | Path,
+    aoi: Polygon | None = None,
+    landcover_classes: dict = LANDCOVER_CLASSES,
 ) -> GeoDataFrame:
     """
     Query OSM features in an OSM-formatted XML file.

--- a/prettymapp/plotting.py
+++ b/prettymapp/plotting.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 import colorsys
-from typing import Tuple, List
-from dataclasses import dataclass
-
-from dataclasses import field
+from dataclasses import dataclass, field
 from geopandas.plotting import _plot_polygon_collection, _plot_linestring_collection
 from geopandas import GeoDataFrame
 import numpy as np
@@ -20,17 +17,17 @@ from prettymapp.settings import STREETS_WIDTH, STYLES
 class Plot:
     """
     Main plotting class for prettymapp.
-    
+
     Args:
         df: GeoDataFrame with the geometries to plot
         aoi_bounds: List of minx, miny, maxx, maxy coordinates, specifying the map extent
         draw_settings: Dictionary of color & draw settings, see prettymapp.settings.STYLES
-        
+
         # Map layout
         shape: the map shape, "circle" or "rectangle"
         contour_width: width of the map contour, defaults to 0
         contour_color: color of the map contour, defaults to "#2F3537"
-        
+
         # Optional map text settings e.g. to display location name
         name_on: whether to display the location name, defaults to False
         name: the location name to display, defaults to "some name"
@@ -40,14 +37,15 @@ class Plot:
         text_y: y-coordinate of the location name, defaults to 0
         text_rotation: rotation of the location name, defaults to 0
         credits: Boolean whether to display the OSM&package credits, defaults to True
-        
+
         # Map background settings
         bg_shape: the map background shape, "circle" or "rectangle", defaults to "circle"
         bg_buffer: buffer around the map, defaults to 2
         bg_color: color of the map background, defaults to "#F2F4CB"
     """
+
     df: GeoDataFrame
-    aoi_bounds: List[
+    aoi_bounds: list[
         float
     ]  # Not df bounds as could lead to weird plot shapes with unequal geometry distribution.
     draw_settings: dict = field(default_factory=lambda: STYLES["Peach"])
@@ -157,7 +155,7 @@ class Plot:
                     geoms=df_class.geometry,
                     values=cmap_values,
                     cmap=cmap,
-                    **draw_settings_class
+                    **draw_settings_class,
                 )
             else:
                 _plot_polygon_collection(
@@ -242,11 +240,14 @@ class Plot:
             size=self.font_size,
         )
 
-    def set_credits(self, text: str = "© OpenStreetMap\n prettymapp | prettymaps", 
-                x: float | None = None, 
-                y: float | None = None, 
-                fontsize: int = 9, 
-                zorder: int = 6):
+    def set_credits(
+        self,
+        text: str = "© OpenStreetMap\n prettymapp | prettymaps",
+        x: float | None = None,
+        y: float | None = None,
+        fontsize: int = 9,
+        zorder: int = 6,
+    ):
         """
         Add OSM credits. Defaults to lower right corner of map.
         """
@@ -258,7 +259,7 @@ class Plot:
         text.set_path_effects([PathEffects.withStroke(linewidth=3, foreground="black")])
 
 
-def adjust_lightness(color: str, amount: float = 0.5) -> Tuple[float, float, float]:
+def adjust_lightness(color: str, amount: float = 0.5) -> tuple[float, float, float]:
     """
     In-/Decrease color brightness amount by factor.
 

--- a/prettymapp/settings.py
+++ b/prettymapp/settings.py
@@ -1,4 +1,3 @@
-
 # Setting `True` will include all subclasses of the class, without having to specify them explicitly.
 LANDCOVER_CLASSES = {
     "urban": {"building": True, "landuse": ["construction", "commercial"]},
@@ -34,7 +33,7 @@ LANDCOVER_CLASSES = {
 
 # Contains drawing settings
 STYLES = {
-    "Peach": { # e.g. Macau
+    "Peach": {  # e.g. Macau
         "urban": {
             "cmap": ["#FFC857", "#E9724C", "#C5283D"],
             "ec": "#2F3737",
@@ -54,7 +53,7 @@ STYLES = {
         "streets": {"fc": "#2F3737", "zorder": 3},
         "other": {"fc": "#F2F4CB", "ec": "#2F3737", "lw": 1, "zorder": 3},
     },
-    "Auburn": { # e.g. Barcelona
+    "Auburn": {  # e.g. Barcelona
         "urban": {
             "cmap": ["#433633", "#FF5E5B", "#FF5E5B"],
             "ec": "#2F3737",
@@ -81,7 +80,7 @@ STYLES = {
         "streets": {"fc": "#2F3737", "zorder": 4},
         "other": {"fc": "#F2F4CB", "ec": "#2F3737", "lw": 1, "zorder": 3},
     },
-    "Citrus": { # e.g. Würzburg
+    "Citrus": {  # e.g. Würzburg
         "urban": {
             "cmap": ["#FFFF3F", "#F4D58D", "#F5CB5C"],
             "ec": "#2F3737",
@@ -106,7 +105,7 @@ STYLES = {
         "streets": {"fc": "#FFFFFF", "zorder": 4},
         "other": {"fc": "#EAE2B7", "ec": "#2F3737", "lw": 1, "zorder": 3},
     },
-    "Flannel": { # e.g. Heerhugowaard
+    "Flannel": {  # e.g. Heerhugowaard
         "urban": {
             "cmap": ["#433633", "#FF5E5B", "#FF5E5B"],
             "ec": "#2F3737",
@@ -130,7 +129,7 @@ STYLES = {
             "zorder": 1,
         },
         "woodland": {"fc": "#64B96A", "ec": "#2F3737", "lw": 1, "zorder": 2},
-        "streets": {"fc": "#2F3737", "zorder": 4, "ec": 475657},
+        "streets": {"fc": "#2F3737", "zorder": 4},
         "other": {"fc": "#F2F4CB", "ec": "#2F3737", "lw": 1, "zorder": 3},
     },
 }

--- a/prettymapp/tests/test_geo.py
+++ b/prettymapp/tests/test_geo.py
@@ -96,6 +96,18 @@ def test_get_aoi_invalid_address_raises():
         get_aoi("not_an_address")
 
 
+def test_get_aoi_empty_address_raises():
+    with pytest.raises(GeoCodingError):
+        get_aoi("   ")
+
+
+@patch("prettymapp.geo.geocode")
+def test_get_aoi_geocode_network_error_raises(mock_geocode):
+    mock_geocode.side_effect = ConnectionError("boom")
+    with pytest.raises(GeoCodingError):
+        get_aoi("Unter den Linden 37, 10117 Berlin")
+
+
 def test_explode_multigeoemtries():
     poly1 = Polygon([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
     poly2 = Polygon([[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]])

--- a/prettymapp/tests/test_osm.py
+++ b/prettymapp/tests/test_osm.py
@@ -1,4 +1,12 @@
-from prettymapp.osm import get_osm_tags, get_osm_geometries_from_xml
+import pytest
+from geopandas import GeoDataFrame
+
+from prettymapp.osm import (
+    get_osm_tags,
+    get_osm_geometries_from_xml,
+    cleanup_osm_df,
+    OsmDataError,
+)
 
 
 def test_get_osm_tags():
@@ -41,3 +49,8 @@ def test_get_osm_geometries_from_xml():
     filepath = "./mock_data/osm_export_xml.osm"
     df = get_osm_geometries_from_xml(filepath)
     assert df.shape == (18, 3)
+
+
+def test_cleanup_osm_df_empty_input_raises():
+    with pytest.raises(OsmDataError):
+        cleanup_osm_df(GeoDataFrame())

--- a/streamlit-prettymapp/app.py
+++ b/streamlit-prettymapp/app.py
@@ -13,6 +13,7 @@ from utils import (
     slugify,
 )
 from prettymapp.geo import GeoCodingError, get_aoi
+from prettymapp.osm import OsmDataError
 from prettymapp.settings import STYLES
 
 st.set_page_config(
@@ -170,7 +171,17 @@ with st.spinner("Creating map... (may take up to a minute)"):
     except GeoCodingError as e:
         st.error(f"ERROR: {str(e)}")
         st.stop()
-    df = st_get_osm_geometries(aoi=aoi)
+    try:
+        df = st_get_osm_geometries(aoi=aoi)
+    except OsmDataError as e:
+        st.error(f"ERROR: {str(e)}")
+        st.stop()
+    except Exception:  # pylint: disable=broad-except
+        st.error(
+            "ERROR: Could not download OpenStreetMap data for this area. "
+            "The service may be busy or unavailable - please try again."
+        )
+        st.stop()
     config = {
         "aoi_bounds": aoi.bounds,
         "draw_settings": draw_settings,
@@ -188,7 +199,11 @@ with st.spinner("Creating map... (may take up to a minute)"):
         "bg_buffer": bg_buffer,
         "bg_color": bg_color,
     }
-    fig = st_plot_all(_df=df, **config)
+    try:
+        fig = st_plot_all(_df=df, **config)
+    except Exception:  # pylint: disable=broad-except
+        st.error("ERROR: Could not render the map for this area. Please try again.")
+        st.stop()
     st.pyplot(fig, pad_inches=0, bbox_inches="tight", transparent=True, dpi=300)
 
 st.markdown("</br>", unsafe_allow_html=True)


### PR DESCRIPTION
Small robustness and cleanup pass — no behavior changes to the happy path.

- Raise a clear `OsmDataError` when an OSM query returns no usable features, instead of crashing on `droplevel` or rendering a blank map
- Surface geocoding network failures and empty addresses as `GeoCodingError`
- Guard the OSM download and plot calls in the Streamlit app so failures show a friendly message instead of a stack trace
- Fix a stray integer color value in the Flannel street style (was dead/misleading)
- Standardize type hints on PEP 604 (`X | None`)

Verified manually: all four styles render (incl. Flannel), empty/no-match OSM results raise `OsmDataError`, and blank-address / geocode-network failures raise `GeoCodingError`. Unit tests added for the new error paths.