### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Update your installation to the latest version:
     ```
 
 ## 0.7.0
-**unreleased**
+**2026-07-08**
 
 - Adds `OsmDataError` and clearer error handling for empty areas and failed geocoding / OSM
   downloads (raises instead of returning empty or crashing).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Update your installation to the latest version:
     pip install prettymapp --upgrade
     ```
 
+## 0.7.0
+**unreleased**
+
+- Adds `OsmDataError` and clearer error handling for empty areas and failed geocoding / OSM
+  downloads (raises instead of returning empty or crashing).
+- Replaces private `geopandas.plotting` functions with public matplotlib collections, and uses
+  the stable top-level `osmnx` API instead of submodule imports - avoids breakage on dependency
+  upgrades.
+- New `dpi` parameter on `Plot` (default 300, previously hardcoded 1200) for much faster, lower-
+  memory rendering.
+- Building colors are now seeded, so identical inputs render identical maps.
+- Fixes an invalid edge color in the `Flannel` streets style.
+- Other: osmnx 2.0 data handling, `osmnx<3` bound with `geopandas`/`shapely` as direct
+  dependencies, faster `explode_multigeometries`, and various test & tooling fixes.
+
 ## 0.6.0
 **December 25, 2025**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prettymapp"
-version = "0.6.0"
+version = "0.7.0"
 description = "Create beautiful maps from OpenStreetMap data"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/streamlit-prettymapp/requirements.txt
+++ b/streamlit-prettymapp/requirements.txt
@@ -2,4 +2,4 @@
 streamlit==1.52.2
 streamlit-image-select==0.6.0
 pyogrio
-prettymapp
+prettymapp>=0.7.0


### PR DESCRIPTION
Release metadata for 0.7.0, split out from the code changes in #85.

**Merge after #85.** This PR only bumps the version, adds the CHANGELOG entry, and pins the Streamlit app to `prettymapp>=0.7.0`. The features/fixes it describes land via #85 (and the already-merged robustness work from #83).

## Changes
- `pyproject.toml`: version `0.6.0` → `0.7.0`
- `CHANGELOG.md`: 0.7.0 entry (set the date at publish time — currently "unreleased")
- `streamlit-prettymapp/requirements.txt`: `prettymapp` → `prettymapp>=0.7.0`

## After merge
- Publish to PyPI: `make package && make upload`